### PR TITLE
Floating animation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -83,7 +83,7 @@
                     </div>
                 </div>
                 <!-- IMAGE -->
-                <img src="../assets/Example.png" alt="Showcase Image" class="zoom ui-image">
+                <img src="../assets/Example.png" alt="Showcase Image" class="zoom">
             </div>
         </div>
     </section>

--- a/docs/style.css
+++ b/docs/style.css
@@ -734,10 +734,10 @@ div label[for=ui-component-toggle__yearly] {
 
   @keyframes up-down {
     0% {
-      transform: translateY(30px); 
+      transform: translateY(15px);
     }
     100% {
-      transform: translateY(-30px); 
+      transform: translateY(-15px);
     }
   }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -728,8 +728,19 @@ div label[for=ui-component-toggle__yearly] {
 
   .ui-image{
     border-radius: 8px;
+    animation: up-down 2s ease-in-out infinite alternate-reverse both;
 
   }
+
+  @keyframes up-down {
+    0% {
+      transform: translateY(30px); 
+    }
+    100% {
+      transform: translateY(-30px); 
+    }
+  }
+
   /*------------------------------------------------------------
   LAYOUT
   ------------------------------------------------------------*/


### PR DESCRIPTION
The Zoom animation image (Example.png) does not zoom when the float animation is added. For this reason `ui-image` from the class name has been removed. Either way it works as intended. 

![ZkGgQ8POqJ](https://user-images.githubusercontent.com/70775520/140834249-a6f9a08b-a1d9-4123-9704-ce6766f12bc3.gif)