### PR TITLE
Added support for adding a custom weapon instead of vandal 

### DIFF
--- a/main.py
+++ b/main.py
@@ -81,18 +81,6 @@ try:
 
     log(f"VALORANT rank yoinker v{version}")
 
-    with open("config.json", "r") as f:
-            json_data = json.load(f)
-            if json_data["weapon"] == "":
-                with open("config.json", "w") as f:
-                    weapon = input("Enter the name of the weapon you use the most (This is for tracking the skins): ")
-                    json_data["weapon"] = weapon
-                    json.dump(json_data, f, indent=4)
-                    log(f"{weapon} weapon has been added to the config file")
-
-
-
-
     valoApiSkins = requests.get("https://valorant-api.com/v1/weapons/skins")
     gameContent = content.get_content()
     seasonID = content.get_latest_season_id(gameContent)

--- a/main.py
+++ b/main.py
@@ -51,8 +51,6 @@ try:
 
     cfg = Config(log)
 
-    weapon = json.load(open("config.json", "r"))["weapon"]
-
     rank = Rank(Requests, log)
 
     content = Content(Requests, log)
@@ -61,6 +59,7 @@ try:
 
     presences = Presences(Requests, log)
 
+    weapon = cfg.weapon
 
     menu = Menu(Requests, log, presences)
     pregame = Pregame(Requests, log)

--- a/main.py
+++ b/main.py
@@ -51,6 +51,8 @@ try:
 
     cfg = Config(log)
 
+    weapon = json.load(open("config.json", "r"))["weapon"]
+
     rank = Rank(Requests, log)
 
     content = Content(Requests, log)
@@ -78,6 +80,15 @@ try:
 
 
     log(f"VALORANT rank yoinker v{version}")
+
+    with open("config.json", "r") as f:
+            json_data = json.load(f)
+            if json_data["weapon"] == "":
+                with open("config.json", "w") as f:
+                    weapon = input("Enter the name of the weapon you use the most (This is for tracking the skins): ")
+                    json_data["weapon"] = weapon
+                    json.dump(json_data, f, indent=4)
+                    log(f"{weapon} weapon has been added to the config file")
 
 
 
@@ -108,7 +119,7 @@ try:
                 server = GAMEPODS[coregame_stats["GamePodID"]]
                 presences.wait_for_presence(namesClass.get_players_puuid(Players))
                 names = namesClass.get_names_from_puuids(Players)
-                loadouts = loadoutsClass.get_match_loadouts(coregame.get_coregame_match_id(), Players, "vandal", valoApiSkins, names, state="game")
+                loadouts = loadoutsClass.get_match_loadouts(coregame.get_coregame_match_id(), Players, f"{weapon}", valoApiSkins, names, state="game")
                 with alive_bar(total=len(Players), title='Fetching Players', bar='classic2') as bar:
                     presence = presences.get_presence()
                     partyOBJ = menu.get_party_json(namesClass.get_players_puuid(Players), presence)
@@ -197,7 +208,7 @@ try:
                 Players = pregame_stats["AllyTeam"]["Players"]
                 presences.wait_for_presence(namesClass.get_players_puuid(Players))
                 names = namesClass.get_names_from_puuids(Players)
-                loadouts = loadoutsClass.get_match_loadouts(pregame.get_pregame_match_id(), pregame_stats, "vandal", valoApiSkins, names,
+                loadouts = loadoutsClass.get_match_loadouts(pregame.get_pregame_match_id(), pregame_stats, f"{weapon}", valoApiSkins, names,
                                               state="pregame")
                 with alive_bar(total=len(Players), title='Fetching Players', bar='classic2') as bar:
                     presence = presences.get_presence()

--- a/main.py
+++ b/main.py
@@ -59,8 +59,6 @@ try:
 
     presences = Presences(Requests, log)
 
-    weapon = cfg.weapon
-
     menu = Menu(Requests, log, presences)
     pregame = Pregame(Requests, log)
     coregame = Coregame(Requests, log)
@@ -106,7 +104,7 @@ try:
                 server = GAMEPODS[coregame_stats["GamePodID"]]
                 presences.wait_for_presence(namesClass.get_players_puuid(Players))
                 names = namesClass.get_names_from_puuids(Players)
-                loadouts = loadoutsClass.get_match_loadouts(coregame.get_coregame_match_id(), Players, f"{weapon}", valoApiSkins, names, state="game")
+                loadouts = loadoutsClass.get_match_loadouts(coregame.get_coregame_match_id(), Players, cfg.weapon, valoApiSkins, names, state="game")
                 with alive_bar(total=len(Players), title='Fetching Players', bar='classic2') as bar:
                     presence = presences.get_presence()
                     partyOBJ = menu.get_party_json(namesClass.get_players_puuid(Players), presence)
@@ -195,7 +193,7 @@ try:
                 Players = pregame_stats["AllyTeam"]["Players"]
                 presences.wait_for_presence(namesClass.get_players_puuid(Players))
                 names = namesClass.get_names_from_puuids(Players)
-                loadouts = loadoutsClass.get_match_loadouts(pregame.get_pregame_match_id(), pregame_stats, f"{weapon}", valoApiSkins, names,
+                loadouts = loadoutsClass.get_match_loadouts(pregame.get_pregame_match_id(), pregame_stats, cfg.weapon, valoApiSkins, names,
                                               state="pregame")
                 with alive_bar(total=len(Players), title='Fetching Players', bar='classic2') as bar:
                     presence = presences.get_presence()

--- a/src/Loadouts.py
+++ b/src/Loadouts.py
@@ -43,7 +43,7 @@ class Loadouts:
                         if skin_id.lower() == skin["uuid"].lower():
                             rgb_color = self.colors.get_rgb_color_from_skin(skin["uuid"].lower(), valoApiSkins)
                             # if rgb_color is not None:
-                            weaponLists.update({players[player]["Subject"]: color(skin["displayName"], fore=rgb_color)})
+                            weaponLists.update({players[player]["Subject"]: color(skin["displayName"].rsplit(" ")[0], fore=rgb_color)})
                             # else:
                             #     weaponLists.update({player["Subject"]: color(skin["Name"], fore=rgb_color)})
         final_json = self.convertLoadoutToJsonArray(PlayerInventorys, playersBackup, state, names)

--- a/src/Loadouts.py
+++ b/src/Loadouts.py
@@ -43,7 +43,7 @@ class Loadouts:
                         if skin_id.lower() == skin["uuid"].lower():
                             rgb_color = self.colors.get_rgb_color_from_skin(skin["uuid"].lower(), valoApiSkins)
                             # if rgb_color is not None:
-                            weaponLists.update({players[player]["Subject"]: color(skin["displayName"].rsplit(" ")[0], fore=rgb_color)})
+                            weaponLists.update({players[player]["Subject"]: color(skin["displayName"], fore=rgb_color)})
                             # else:
                             #     weaponLists.update({player["Subject"]: color(skin["Name"], fore=rgb_color)})
         final_json = self.convertLoadoutToJsonArray(PlayerInventorys, playersBackup, state, names)

--- a/src/config.py
+++ b/src/config.py
@@ -2,12 +2,20 @@ import json
 from io import TextIOWrapper
 from json import JSONDecodeError
 import requests
+import os
 
 from src.logs import Logging
 
 class Config:
     def __init__(self, log):
         self.log = log
+
+        if not os.path.exists("config.json"):
+            self.log("config.json not found, creating new one")
+            with open("config.json", "w") as file:
+                config = self.config_dialog(file)
+            
+
         try:
             with open("config.json", "r") as file:
                 self.log("config opened")
@@ -17,25 +25,31 @@ class Config:
                     config = self.config_dialog(file)
 
                 if config["weapon"] == "":
+                    weapon = input("Enter the name of the weapon you use the most (This is for tracking the skins): ").capitalize().strip()
+                    self.log(f"User inputted {weapon} as the weapon")
                     with open("config.json", "w") as f:
-                        weapon = input("Enter the name of the weapon you use the most (This is for tracking the skins): ").capitalize().strip()
-                        self.log(f"User inputted {weapon} as the weapon")
-                        if weapon not in [weapon["displayName"] for weapon in requests.get("https://valorant-api.com/v1/weapons").json()["data"]]:
+                        if not self.weapon_check(weapon):
                             config["weapon"] = "vandal"
                             json.dump(config, f, indent=4)
-                            self.log(f"{weapon} weapon has been added to the config file by default")
+                            self.log("vandal weapon has been added to the config file by default")
                         else:
                             config["weapon"] = weapon
                             json.dump(config, f, indent=4)
                             self.log(f"{weapon} weapon has been added to the config file by user")
                 
-        except (FileNotFoundError, JSONDecodeError):
-            self.log("file not found or invalid file")
+        except (JSONDecodeError):
+            self.log("invalid file")
             with open("config.json", "w") as file:
                 config = self.config_dialog(file)
         finally:
             self.cooldown = config["cooldown"]
             self.log(f"got cooldown with value '{self.cooldown}'")
+
+            if not self.weapon_check(config["weapon"]):
+                    self.weapon = "vandal" # if the user manually entered a wrong name into the config file, this will be the default until changed by the user.
+            else:   
+                self.weapon = config["weapon"]
+                
 
     def config_dialog(self, fileToWrite: TextIOWrapper):
         self.log("color config prompt called")
@@ -43,3 +57,9 @@ class Config:
         
         json.dump(jsonToWrite, fileToWrite)
         return jsonToWrite
+
+    def weapon_check(self, name):
+        if name in [weapon["displayName"] for weapon in requests.get("https://valorant-api.com/v1/weapons").json()["data"]]:
+            return True
+        else:
+            return False

--- a/src/config.py
+++ b/src/config.py
@@ -14,6 +14,14 @@ class Config:
                 if config.get("cooldown") is None:
                     self.log("some config values are None, getting new config")
                     config = self.config_dialog(file)
+
+                if config["weapon"] == "":
+                    with open("config.json", "w") as f:
+                        weapon = input("Enter the name of the weapon you use the most (This is for tracking the skins): ")
+                        config["weapon"] = weapon
+                        json.dump(config, f, indent=4)
+                        self.log(f"{weapon} weapon has been added to the config file")
+                
         except (FileNotFoundError, JSONDecodeError):
             self.log("file not found or invalid file")
             with open("config.json", "w") as file:

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,7 @@
 import json
 from io import TextIOWrapper
 from json import JSONDecodeError
+import requests
 
 from src.logs import Logging
 
@@ -17,10 +18,16 @@ class Config:
 
                 if config["weapon"] == "":
                     with open("config.json", "w") as f:
-                        weapon = input("Enter the name of the weapon you use the most (This is for tracking the skins): ")
-                        config["weapon"] = weapon
-                        json.dump(config, f, indent=4)
-                        self.log(f"{weapon} weapon has been added to the config file")
+                        weapon = input("Enter the name of the weapon you use the most (This is for tracking the skins): ").capitalize().strip()
+                        self.log(f"User inputted {weapon} as the weapon")
+                        if weapon not in [weapon["displayName"] for weapon in requests.get("https://valorant-api.com/v1/weapons").json()["data"]]:
+                            config["weapon"] = "vandal"
+                            json.dump(config, f, indent=4)
+                            self.log(f"{weapon} weapon has been added to the config file by default")
+                        else:
+                            config["weapon"] = weapon
+                            json.dump(config, f, indent=4)
+                            self.log(f"{weapon} weapon has been added to the config file by user")
                 
         except (FileNotFoundError, JSONDecodeError):
             self.log("file not found or invalid file")

--- a/src/config.py
+++ b/src/config.py
@@ -24,6 +24,7 @@ class Config:
 
     def config_dialog(self, fileToWrite: TextIOWrapper):
         self.log("color config prompt called")
-        jsonToWrite = {"cooldown": 1}
+        jsonToWrite = {"cooldown": 1, "weapon":""}
+        
         json.dump(jsonToWrite, fileToWrite)
         return jsonToWrite


### PR DESCRIPTION
Saw a lot of people on discord asking if they can change the default vandal to phantom etc.. So with this PR they should be able to do so.
After the config file is created the user is asked to enter a weapon they use the most `(The message could be cleaned up a bit I just wrote it as an example)` after they enter the name it will be stored in the config file. Because it's stored in the config file and is not hardcoded the user can later change the weapon name without having to change the code and compile themselves like how it is now. 