### PR TITLE
Fix call to LockfileError to include self parameter

### DIFF
--- a/src/requests.py
+++ b/src/requests.py
@@ -125,7 +125,7 @@ class Requests:
     def get_lockfile(self):
         path = os.path.join(os.getenv('LOCALAPPDATA'), R'Riot Games\Riot Client\Config\lockfile')
         
-        if self.Error.LockfileError(path):
+        if self.Error.LockfileError(self.Error, path):
             with open(path) as lockfile:
                 self.log("opened lockfile")
                 data = lockfile.read().split(':')


### PR DESCRIPTION
Previous commit did not include the self parameter in this function call, which crashed the program immediately 