### PR TITLE
Fix error logging again

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ try:
 
     ErrorSRC = Error(log)
     
-    Requests = Requests(version, log, Error)
+    Requests = Requests(version, log, ErrorSRC)
     Requests.check_version()
     Requests.check_status()
 

--- a/src/requests.py
+++ b/src/requests.py
@@ -125,7 +125,7 @@ class Requests:
     def get_lockfile(self):
         path = os.path.join(os.getenv('LOCALAPPDATA'), R'Riot Games\Riot Client\Config\lockfile')
         
-        if self.Error.LockfileError(self.Error, path):
+        if self.Error.LockfileError(path):
             with open(path) as lockfile:
                 self.log("opened lockfile")
                 data = lockfile.read().split(':')


### PR DESCRIPTION
Use instance of Error class, not reference to Error class
Tested in my local environment, seems to work now
Script starts and runs as expected, logging if lockfile is not found