### PR TITLE
add import to avoid error when compiled with cx_freeze

### DIFF
--- a/src/websocket.py
+++ b/src/websocket.py
@@ -1,7 +1,6 @@
 import websockets
+import websockets.client
 import ssl
-import os
-import asyncio
 import base64
 import json
 
@@ -84,4 +83,3 @@ class Ws:
     # loop = asyncio.new_event_loop()
     # asyncio.set_event_loop(loop)
     # loop.run_forever()
-    


### PR DESCRIPTION
I was getting an error about websockets.legacy.client module not being found when I didn't have this import. It worked fine when running from source. The removed imports are unused.