### PR TITLE
fix logging error

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -28,7 +28,7 @@ class Config:
                 if len(missingkeys) > 0:
                     self.log("config.json is missing keys")
                     with open("config.json", 'w') as w:
-                        self.log(f"missing keys: " + {str(missingkeys)})
+                        self.log(f"missing keys: " + str(missingkeys))
                         for key in missingkeys:
                             config[key] = self.default[key]
 


### PR DESCRIPTION
This was erroring out when I ran with an empty config.json file b/c it was adding string and set with the + operator. 

Now it produces this output:
```
[2022.07.14-21.06.58] config opened
[2022.07.14-21.06.58] config.json is missing keys
[2022.07.14-21.06.58] missing keys: ['cooldown', 'weapon', 'port', 'table']
[2022.07.14-21.06.58] Succesfully added missing keys
```