### PR TITLE
Add build of compiled python app on push to main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build
+
+env:
+  PYTHON_VERSION: '3.10'
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+          cache-dependency-path: 'requirements.txt'
+      - name: Install Dependencies
+        run: pip install -r requirements.txt
+      - name: Install cx_Freeze
+        run: pip install cx_Freeze
+      - name: Build Native Executable
+        run: python setup.py build
+      - name: Get commit hash
+        id: commit
+        uses: pr-mpt/actions-commit-hash@v1
+      - name: Upload Compiled Version
+        uses: actions/upload-artifact@v3
+        with:
+          name: VALORANT-rank-yoinker-${{ steps.commit.outputs.short }}
+          path: build/exe.win-amd64-${{ env.PYTHON_VERSION }}/**

--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@
 
 > `-` View all skins: <https://vry.netlify.app/matchLoadouts>.
 
+### Letting Github Build It:
+
+The latest commits to the `main` branch will be built by a [Github Actions](https://github.com/isaacKenyon/VALORANT-rank-yoinker/actions) workflow 
+and a successful build should result in a compiled artifact that you can download and try out.
+See the [Actions tab](https://github.com/isaacKenyon/VALORANT-rank-yoinker/actions), click on the `Build` workflow, 
+select a particular workflow run, and it should have an artifact available for download. 
+
+If you want to make a small change to the application, you can:
+1) [Fork](https://github.com/isaacKenyon/VALORANT-rank-yoinker/fork) this project.
+2) Change the code in your forked repository.
+3) Let the Github Actions workflow build vRY.exe for you.
+4) Download it and test it.
+5) Submit a Pull Request if you would like your change included in future releases.
+
 ## What about that Tweet?
 
  The [Tweet](https://twitter.com/PlayVALORANT/status/1539728676815642624), which details Riot's API policies outlines how


### PR DESCRIPTION
This adds an automated build of the compiled python code that can be downloaded and run, similar to a release zip. You can see an example of the build and download the artifact from: [here](https://github.com/hdeadman/VALORANT-rank-yoinker/actions/runs/2702206283)

- checks out code
- installs dependencies (or downloads pip cache)
- installs cx_Freeze
- builds python executable
- zips compiled files b/c uploading files individually was slow
- uploads the zip as an artifact
- people can download the artifact from the Actions tab

Maybe it's not that useful b/c users can't customize anything but at least it shows the build process.

This results in a zipped zip file which requires two unzips.
It is possible to upload all the 2000 files so that they are in one zipped artifact but it's painful to watch and takes about 4.5 minutes for that step to complete. 

