### PR TITLE
Add check for empty private presence field

### DIFF
--- a/src/presences.py
+++ b/src/presences.py
@@ -26,6 +26,8 @@ class Presences:
                 if presence.get("championId") is not None or presence.get("product") == "league_of_legends":
                     return None
                 else:
+                    if presence['private'] == "": 
+                        return None
                     decoded_private = json.loads(base64.b64decode(presence['private']))
                     # Debug
                     # print(f"DEBUG: Decoded Private Presence -> {decoded_private}")


### PR DESCRIPTION
Getting the following crash because `presence['private']` is `''` so the decode fails. 

```
[2025.10.05-23.38.53] Traceback (most recent call last):
  File "main.py", line 189, in <module>
    private_presence = presences.get_private_presence(presence)
  File "C:\Users\annde\work\VALORANT-rank-yoinker\src\presences.py", line 29, in get_private_presence
    decoded_private = json.loads(base64.b64decode(presence['private']))
  File "C:\Users\annde\AppData\Local\Programs\Python\Python310\lib\json\__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "C:\Users\annde\AppData\Local\Programs\Python\Python310\lib\json\decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "C:\Users\annde\AppData\Local\Programs\Python\Python310\lib\json\decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

