### PR TITLE
Remove Starting Side

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,7 +43,6 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 os.system(f"title VALORANT rank yoinker v{version}")
 
 server = ""
-team_side = None
 
 
 def program_exit(status: int):  # so we don't need to import the entire sys module
@@ -1006,11 +1005,7 @@ try:
                 time.sleep(9)
             
             title_parts = [f"VALORANT status: {title}"]
-            
-            if game_state == "PREGAME" and pregame_stats is not None and cfg.get_feature_flag("starting_side"):
-                team_side = "Attacker" if pregame_stats["AllyTeam"]["TeamID"] == "Red" else "Defender"
-                title_parts.append(f" | {colr(team_side, fore=(76, 151, 237) if team_side == 'Defender' else (238, 77, 77))}")
-            
+
             if cfg.get_feature_flag("server_id") and server != "":
                 parts = server.split('.')
                 if len(parts) > 2:

--- a/src/constants.py
+++ b/src/constants.py
@@ -188,34 +188,33 @@ WEAPONS = [
 ]
 
 DEFAULT_CONFIG = {
-        "cooldown": 10,
-        "port": 1100,
-        "weapon": "Vandal",
-        "chat_limit": 5,
-        "table": {
-            "skin": True,
-            "rr": True,
-            "earned_rr": True,
-            "peakrank": True,
-            "previousrank" : False,
-            "leaderboard": True,
-            "headshot_percent": True,
-            "winrate": True,
-            "kd": False,
-            "level": True
-        },
-        "flags": {
-            "last_played": True,
-            "auto_hide_leaderboard": True,
-            "pre_cls": False,
-            "game_chat": True,
-            "peak_rank_act": True,
-            "discord_rpc": True,
-            "aggregate_rank_rr": True,
-            "server_id": False,
-            "short_ranks": False,
-            "truncate_skins": True,
-            "truncate_names": True,
-            "starting_side": False
-        }
+    "cooldown": 10,
+    "port": 1100,
+    "weapon": "Vandal",
+    "chat_limit": 5,
+    "table": {
+        "skin": True,
+        "rr": True,
+        "earned_rr": True,
+        "peakrank": True,
+        "previousrank": False,
+        "leaderboard": True,
+        "headshot_percent": True,
+        "winrate": True,
+        "kd": False,
+        "level": True
+    },
+    "flags": {
+        "last_played": True,
+        "auto_hide_leaderboard": True,
+        "pre_cls": False,
+        "game_chat": True,
+        "peak_rank_act": True,
+        "discord_rpc": True,
+        "aggregate_rank_rr": True,
+        "server_id": False,
+        "short_ranks": False,
+        "truncate_skins": True,
+        "truncate_names": True,
     }
+}

--- a/src/questions.py
+++ b/src/questions.py
@@ -26,7 +26,7 @@ FLAGS_OPTS = {
     "short_ranks": "Short rank names instead of long ones",
     "truncate_skins": "Truncate long skin names if the window is too small",
     "truncate_names": "Truncate long player names if the window is too small",
-    "starting_side": "Display starting side (Attacker/Defender) while in the pregame lobby"
+
 }
 
 weapon_question = lambda config: {


### PR DESCRIPTION
# This pull request completely removes the option now clarified as prohibited by Riot.

## Context:

> It was a feature bordering on interpretation, making certainty impossible; however, an alleged Rioter warned us about it, and a user was reportedly penalized at the same time. Although the feature has existed for months, a new release occurred only today, so all indications point to this being a genuine, friendly warning from Riot monitoring new releases of popular tools.
