### PR TITLE
Add Bandit support (patch 12.00 new weapon)

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -163,6 +163,7 @@ tierDict = {
         }
 
 WEAPONS = [
+    "Bandit",
     "Classic",
     "Shorty",
     "Frenzy",


### PR DESCRIPTION
Adds support for the [newly introduced weapon, Bandit, in Season 2026 (patch 12.00)](https://playvalorant.com/en-us/news/game-updates/valorant-patch-notes-12-00/) when running the configurator using `--config` flag:

```bash
python main.py --config
```

<img width="503" height="424" alt="image" src="https://github.com/user-attachments/assets/c01df0fd-e37e-4ab1-9420-07b6c70f7c8c" />

<img width="864" height="244" alt="1" src="https://github.com/user-attachments/assets/41998a70-c2a6-45b5-a8ff-41c27a98e5c5" />