### PR TITLE
Fix Loadouts IndexError

### DIFF
--- a/src/Loadouts.py
+++ b/src/Loadouts.py
@@ -17,23 +17,31 @@ class Loadouts:
     def get_match_loadouts(self, match_id, players, weaponChoose, valoApiSkins, names, state="game"):
         playersBackup = players
         weaponLists = {}
-        valApiWeapons = requests.get("https://valorant-api.com/v1/weapons").json()
+        valApiWeapons = requests.get(
+            "https://valorant-api.com/v1/weapons").json()
         if state == "game":
             team_id = "Blue"
-            PlayerInventorys = self.Requests.fetch("glz", f"/core-game/v1/matches/{match_id}/loadouts", "get")
+            PlayerInventorys = self.Requests.fetch(
+                "glz", f"/core-game/v1/matches/{match_id}/loadouts", "get")
         elif state == "pregame":
             pregame_stats = players
             players = players["AllyTeam"]["Players"]
             team_id = pregame_stats['Teams'][0]['TeamID']
-            PlayerInventorys = self.Requests.fetch("glz", f"/pregame/v1/matches/{match_id}/loadouts", "get")
-        for player in range(len(players)):
-            if team_id == "Red":
-                invindex = player + len(players) - len(PlayerInventorys["Loadouts"])
-            else:
-                invindex = player
-            inv = PlayerInventorys["Loadouts"][invindex]
-            if state == "game":
-                inv = inv["Loadout"]
+            PlayerInventorys = self.Requests.fetch(
+                "glz", f"/pregame/v1/matches/{match_id}/loadouts", "get")
+
+        # CharacterID -> Loadout lookup
+        loadout_by_character = {}
+        for loadout_entry in PlayerInventorys["Loadouts"]:
+            char_id = loadout_entry.get("CharacterID", "").lower()
+            if char_id:
+                loadout_by_character[char_id] = loadout_entry["Loadout"] if state == "game" else loadout_entry
+
+        for player in players:
+            char_id = player.get("CharacterID", "").lower()
+            inv = loadout_by_character.get(char_id)
+            if inv is None:
+                continue
             for weapon in valApiWeapons["data"]:
                 if weapon["displayName"].lower() == weaponChoose.lower():
                     skin_id = \
@@ -44,30 +52,36 @@ class Loadouts:
                     if "data" not in json_data:
                         self.log("Skins API response missing 'data'.")
                         return None
-                    
+
                     for skin in json_data["data"]:
                         if skin_id.lower() == skin["uuid"].lower():
-                            rgb_color = self.colors.get_rgb_color_from_skin(skin["uuid"].lower(), valoApiSkins)
-                            skin_display_name = skin["displayName"].replace(f" {weapon['displayName']}", "")
+                            rgb_color = self.colors.get_rgb_color_from_skin(
+                                skin["uuid"].lower(), valoApiSkins)
+                            skin_display_name = skin["displayName"].replace(
+                                f" {weapon['displayName']}", "")
                             # if rgb_color is not None:
-                            weaponLists.update({players[player]["Subject"]: color(skin_display_name, fore=rgb_color)})
+                            weaponLists.update({player["Subject"]: color(
+                                skin_display_name, fore=rgb_color)})
                             # else:
                             #     weaponLists.update({player["Subject"]: color(skin["Name"], fore=rgb_color)})
-        final_json = self.convertLoadoutToJsonArray(PlayerInventorys, playersBackup, state, names)
+        final_json = self.convertLoadoutToJsonArray(
+            PlayerInventorys, playersBackup, state, names)
         # self.log(f"json for website: {final_json}")
-        self.Server.send_payload("matchLoadout",final_json)
-        return [weaponLists,final_json]
+        self.Server.send_payload("matchLoadout", final_json)
+        return [weaponLists, final_json]
 
-    #this will convert valorant loadouts to json with player names
+    # this will convert valorant loadouts to json with player names
     def convertLoadoutToJsonArray(self, PlayerInventorys, players, state, names):
-        #get agent dict from main in future
+        # get agent dict from main in future
         # names = self.namesClass.get_names_from_puuids(players)
         valoApiSprays = requests.get("https://valorant-api.com/v1/sprays")
         valoApiWeapons = requests.get("https://valorant-api.com/v1/weapons")
         valoApiBuddies = requests.get("https://valorant-api.com/v1/buddies")
         valoApiAgents = requests.get("https://valorant-api.com/v1/agents")
-        valoApiTitles = requests.get("https://valorant-api.com/v1/playertitles")
-        valoApiPlayerCards = requests.get("https://valorant-api.com/v1/playercards")
+        valoApiTitles = requests.get(
+            "https://valorant-api.com/v1/playertitles")
+        valoApiPlayerCards = requests.get(
+            "https://valorant-api.com/v1/playercards")
 
         final_final_json = {"Players": {},
                             "time": int(time.time()),
@@ -76,103 +90,119 @@ class Loadouts:
         final_json = final_final_json["Players"]
         if state == "game":
             PlayerInventorys = PlayerInventorys["Loadouts"]
-            for i in range(len(PlayerInventorys)):
-                PlayerInventory = PlayerInventorys[i]["Loadout"]
+
+            # CharacterID -> Player lookup
+            player_by_character = {
+                p.get("CharacterID", "").lower(): p for p in players}
+
+            for loadout_entry in PlayerInventorys:
+                char_id = loadout_entry.get("CharacterID", "").lower()
+                player = player_by_character.get(char_id)
+                if player is None:
+                    continue
+
+                subject = player["Subject"]
+                PlayerInventory = loadout_entry["Loadout"]
                 final_json.update(
                     {
-                        players[i]["Subject"]: {}
+                        subject: {}
                     }
                 )
 
-                #creates name field
+                # creates name field
                 if hide_names:
                     for agent in valoApiAgents.json()["data"]:
-                        if agent["uuid"] == players[i]["CharacterID"]:
-                            final_json[players[i]["Subject"]].update({"Name": agent["displayName"]})
+                        if agent["uuid"] == player["CharacterID"]:
+                            final_json[subject].update(
+                                {"Name": agent["displayName"]})
                 else:
-                    final_json[players[i]["Subject"]].update({"Name": names[players[i]["Subject"]]})
+                    final_json[subject].update({"Name": names[subject]})
 
-                #creates team field
-                final_json[players[i]["Subject"]].update({"Team": players[i]["TeamID"]})
+                # creates team field
+                final_json[subject].update({"Team": player["TeamID"]})
 
-                #create spray field
-                final_json[players[i]["Subject"]].update({"Sprays": {}})
-                #append sprays to field
+                # create spray field
+                final_json[subject].update({"Sprays": {}})
+                # append sprays to field
 
-                final_json[players[i]["Subject"]].update({"Level": players[i]["PlayerIdentity"]["AccountLevel"]})
+                final_json[subject].update(
+                    {"Level": player["PlayerIdentity"]["AccountLevel"]})
 
                 for title in valoApiTitles.json()["data"]:
-                    if title["uuid"] == players[i]["PlayerIdentity"]["PlayerTitleID"]:
-                        final_json[players[i]["Subject"]].update({"Title": title["titleText"]})
-
+                    if title["uuid"] == player["PlayerIdentity"]["PlayerTitleID"]:
+                        final_json[subject].update(
+                            {"Title": title["titleText"]})
 
                 for PCard in valoApiPlayerCards.json()["data"]:
-                    if PCard["uuid"] == players[i]["PlayerIdentity"]["PlayerCardID"]:
-                        final_json[players[i]["Subject"]].update({"PlayerCard": PCard["largeArt"]})
+                    if PCard["uuid"] == player["PlayerIdentity"]["PlayerCardID"]:
+                        final_json[subject].update(
+                            {"PlayerCard": PCard["largeArt"]})
 
                 for agent in valoApiAgents.json()["data"]:
-                    if agent["uuid"] == players[i]["CharacterID"]:
-                        final_json[players[i]["Subject"]].update({"AgentArtworkName": agent["displayName"] + "Artwork"})
-                        final_json[players[i]["Subject"]].update({"Agent": agent["displayIcon"]})
+                    if agent["uuid"] == player["CharacterID"]:
+                        final_json[subject].update(
+                            {"AgentArtworkName": agent["displayName"] + "Artwork"})
+                        final_json[subject].update(
+                            {"Agent": agent["displayIcon"]})
 
                 spray_selections = [
                     s for s in PlayerInventory.get("Expressions", {}).get("AESSelections", [])
                     if s.get("TypeID") == "d5f120f8-ff8c-4aac-92ea-f2b5acbe9475"
                 ]
                 for j, spray in enumerate(spray_selections):
-                    final_json[players[i]["Subject"]]["Sprays"].update({j: {}})
+                    final_json[subject]["Sprays"].update({j: {}})
                     for sprayValApi in valoApiSprays.json()["data"]:
                         if spray["AssetID"].lower() == sprayValApi["uuid"].lower():
-                            final_json[players[i]["Subject"]]["Sprays"][j].update({
+                            final_json[subject]["Sprays"][j].update({
                                 "displayName": sprayValApi["displayName"],
                                 "displayIcon": sprayValApi["displayIcon"],
                                 "fullTransparentIcon": sprayValApi["fullTransparentIcon"]
                             })
 
-                #create weapons field
-                final_json[players[i]["Subject"]].update({"Weapons": {}})
+                # create weapons field
+                final_json[subject].update({"Weapons": {}})
 
                 for skin in PlayerInventory["Items"]:
 
-                    #create skin field
-                    final_json[players[i]["Subject"]]["Weapons"].update({skin: {}})
+                    # create skin field
+                    final_json[subject]["Weapons"].update({skin: {}})
 
                     for socket in PlayerInventory["Items"][skin]["Sockets"]:
-                        #predefined sockets
+                        # predefined sockets
                         for var_socket in sockets:
                             if socket == sockets[var_socket]:
-                                final_json[players[i]["Subject"]]["Weapons"][skin].update(
+                                final_json[subject]["Weapons"][skin].update(
                                     {
                                         var_socket: PlayerInventory["Items"][skin]["Sockets"][socket]["Item"]["ID"]
                                     }
                                 )
 
-                    #create buddy field
+                    # create buddy field
                     # self.log("predefined sockets")
-                    # final_json[players[i]["Subject"]]["Weapons"].update({skin: {}})
+                    # final_json[subject]["Weapons"].update({skin: {}})
 
-                    #buddies
+                    # buddies
                     for socket in PlayerInventory["Items"][skin]["Sockets"]:
                         if sockets["skin_buddy"] == socket:
                             for buddy in valoApiBuddies.json()["data"]:
                                 if buddy["uuid"] == PlayerInventory["Items"][skin]["Sockets"][socket]["Item"]["ID"]:
-                                    final_json[players[i]["Subject"]]["Weapons"][skin].update(
+                                    final_json[subject]["Weapons"][skin].update(
                                         {
                                             "buddy_displayIcon": buddy["displayIcon"]
                                         }
                                     )
 
-                    #append names to field
+                    # append names to field
                     for weapon in valoApiWeapons.json()["data"]:
                         if skin == weapon["uuid"]:
-                            final_json[players[i]["Subject"]]["Weapons"][skin].update(
+                            final_json[subject]["Weapons"][skin].update(
                                 {
                                     "weapon": weapon["displayName"]
                                 }
                             )
                             for skinValApi in weapon["skins"]:
                                 if skinValApi["uuid"] == PlayerInventory["Items"][skin]["Sockets"][sockets["skin"]]["Item"]["ID"]:
-                                    final_json[players[i]["Subject"]]["Weapons"][skin].update(
+                                    final_json[subject]["Weapons"][skin].update(
                                         {
                                             "skinDisplayName": skinValApi["displayName"]
                                         }
@@ -180,30 +210,30 @@ class Loadouts:
                                     for chroma in skinValApi["chromas"]:
                                         if chroma["uuid"] == PlayerInventory["Items"][skin]["Sockets"][sockets["skin_chroma"]]["Item"]["ID"]:
                                             if chroma["displayIcon"] != None:
-                                                final_json[players[i]["Subject"]]["Weapons"][skin].update(
+                                                final_json[subject]["Weapons"][skin].update(
                                                     {
                                                         "skinDisplayIcon": chroma["displayIcon"]
                                                     }
                                                 )
                                             elif chroma["fullRender"] != None:
-                                                final_json[players[i]["Subject"]]["Weapons"][skin].update(
+                                                final_json[subject]["Weapons"][skin].update(
                                                     {
                                                         "skinDisplayIcon": chroma["fullRender"]
                                                     }
                                                 )
                                             elif skinValApi["displayIcon"] != None:
-                                                final_json[players[i]["Subject"]]["Weapons"][skin].update(
+                                                final_json[subject]["Weapons"][skin].update(
                                                     {
                                                         "skinDisplayIcon": skinValApi["displayIcon"]
                                                     }
                                                 )
                                             else:
-                                                final_json[players[i]["Subject"]]["Weapons"][skin].update(
+                                                final_json[subject]["Weapons"][skin].update(
                                                     {
                                                         "skinDisplayIcon": skinValApi["levels"][0]["displayIcon"]
                                                     }
                                                 )
                                     if skinValApi["displayName"].startswith("Standard") or skinValApi["displayName"].startswith("Melee"):
-                                        final_json[players[i]["Subject"]]["Weapons"][skin]["skinDisplayIcon"] = weapon["displayIcon"]
+                                        final_json[subject]["Weapons"][skin]["skinDisplayIcon"] = weapon["displayIcon"]
 
         return final_final_json

--- a/src/constants.py
+++ b/src/constants.py
@@ -84,46 +84,46 @@ AGENTCOLORLIST = {
 
 symbol = "■"
 PARTYICONLIST = [
-            color(symbol, fore=(227, 67, 67)),
-            color(symbol, fore=(216, 67, 227)),
-            color(symbol, fore=(67, 70, 227)),
-            color(symbol, fore=(67, 227, 208)),
-            color(symbol, fore=(94, 227, 67)),
-            color(symbol, fore=(226, 237, 57)),
-            color(symbol, fore=(212, 82, 207)),
-            symbol
-        ]
+    color(symbol, fore=(227, 67, 67)),
+    color(symbol, fore=(216, 67, 227)),
+    color(symbol, fore=(67, 70, 227)),
+    color(symbol, fore=(67, 227, 208)),
+    color(symbol, fore=(94, 227, 67)),
+    color(symbol, fore=(226, 237, 57)),
+    color(symbol, fore=(212, 82, 207)),
+    symbol
+]
 
 NUMBERTORANKS = [
-            color('Unranked', fore=(46, 46, 46)),
-            color('Unranked', fore=(46, 46, 46)),
-            color('Unranked', fore=(46, 46, 46)),
-            color('Iron 1', fore=(72, 69, 62)),
-            color('Iron 2', fore=(72, 69, 62)),
-            color('Iron 3', fore=(72, 69, 62)),
-            color('Bronze 1', fore=(187, 143, 90)),
-            color('Bronze 2', fore=(187, 143, 90)),
-            color('Bronze 3', fore=(187, 143, 90)),
-            color('Silver 1', fore=(174, 178, 178)),
-            color('Silver 2', fore=(174, 178, 178)),
-            color('Silver 3', fore=(174, 178, 178)),
-            color('Gold 1', fore=(197, 186, 63)),
-            color('Gold 2', fore=(197, 186, 63)),
-            color('Gold 3', fore=(197, 186, 63)),
-            color('Platinum 1', fore=(24, 167, 185)),
-            color('Platinum 2', fore=(24, 167, 185)),
-            color('Platinum 3', fore=(24, 167, 185)),
-            color('Diamond 1', fore=(216, 100, 199)),
-            color('Diamond 2', fore=(216, 100, 199)),
-            color('Diamond 3', fore=(216, 100, 199)),
-            color('Ascendant 1', fore=(24, 148, 82)),
-            color('Ascendant 2', fore=(24, 148, 82)),
-            color('Ascendant 3', fore=(24, 148, 82)),
-            color('Immortal 1', fore=(221, 68, 68)),
-            color('Immortal 2', fore=(221, 68, 68)),
-            color('Immortal 3', fore=(221, 68, 68)),
-            color('Radiant', fore=(255, 253, 205)),
-        ]
+    color('Unranked', fore=(46, 46, 46)),
+    color('Unranked', fore=(46, 46, 46)),
+    color('Unranked', fore=(46, 46, 46)),
+    color('Iron 1', fore=(72, 69, 62)),
+    color('Iron 2', fore=(72, 69, 62)),
+    color('Iron 3', fore=(72, 69, 62)),
+    color('Bronze 1', fore=(187, 143, 90)),
+    color('Bronze 2', fore=(187, 143, 90)),
+    color('Bronze 3', fore=(187, 143, 90)),
+    color('Silver 1', fore=(174, 178, 178)),
+    color('Silver 2', fore=(174, 178, 178)),
+    color('Silver 3', fore=(174, 178, 178)),
+    color('Gold 1', fore=(197, 186, 63)),
+    color('Gold 2', fore=(197, 186, 63)),
+    color('Gold 3', fore=(197, 186, 63)),
+    color('Platinum 1', fore=(24, 167, 185)),
+    color('Platinum 2', fore=(24, 167, 185)),
+    color('Platinum 3', fore=(24, 167, 185)),
+    color('Diamond 1', fore=(216, 100, 199)),
+    color('Diamond 2', fore=(216, 100, 199)),
+    color('Diamond 3', fore=(216, 100, 199)),
+    color('Ascendant 1', fore=(24, 148, 82)),
+    color('Ascendant 2', fore=(24, 148, 82)),
+    color('Ascendant 3', fore=(24, 148, 82)),
+    color('Immortal 1', fore=(221, 68, 68)),
+    color('Immortal 2', fore=(221, 68, 68)),
+    color('Immortal 3', fore=(221, 68, 68)),
+    color('Radiant', fore=(255, 253, 205)),
+]
 
 SHORT_NUMBERTORANKS = [
     color('UnR', fore=(46, 46, 46)),
@@ -157,16 +157,15 @@ SHORT_NUMBERTORANKS = [
 ]
 
 tierDict = {
-            "0cebb8be-46d7-c12a-d306-e9907bfc5a25": (0, 149, 135),
-            "e046854e-406c-37f4-6607-19a9ba8426fc": (241, 184, 45),
-            "60bca009-4182-7998-dee7-b8a2558dc369": (209, 84, 141),
-            "12683d76-48d7-84a3-4e09-6985794f0445": (90, 159, 226),
-            "411e4a55-4e59-7757-41f0-86a53f101bb5": (239, 235, 101),
-            None: None
-        }
+    "0cebb8be-46d7-c12a-d306-e9907bfc5a25": (0, 149, 135),
+    "e046854e-406c-37f4-6607-19a9ba8426fc": (241, 184, 45),
+    "60bca009-4182-7998-dee7-b8a2558dc369": (209, 84, 141),
+    "12683d76-48d7-84a3-4e09-6985794f0445": (90, 159, 226),
+    "411e4a55-4e59-7757-41f0-86a53f101bb5": (239, 235, 101),
+    None: None
+}
 
 WEAPONS = [
-    "Bandit",
     "Classic",
     "Shorty",
     "Frenzy",


### PR DESCRIPTION
Fixes a `IndexError` crash in the loadout logic and removes a duplicate entry from the constants.

* **`Loadouts.py`:** Replaced the unsafe index-based iteration (which relied on `players` and `loadouts` lists being synchronized in size) with a dictionary lookup. This prevents `IndexError: list index out of range` crashes when the API returns fewer loadouts than the number of players (eg: player left during a deathmatch).
* **`constants.py`:** Removed the duplicate "Bandits" entry from the weapon list.