### PR TITLE
py-upgrade: Resolve compatibility and API fixes for >py3.12

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import traceback
 
 import requests
 import urllib3
-from colr import color as colr
+from src.colors import color as colr
 from InquirerPy import inquirer
 from rich.console import Console as RichConsole
 
@@ -124,7 +124,7 @@ try:
 
     current_map = coregame.get_current_map(map_urls, map_splashes)
 
-    colors = Colors(log, hide_names, agent_dict, AGENTCOLORLIST)
+    colors = Colors(log, hide_names, agent_dict, AGENTCOLORLIST, tierDict)
 
     loadoutsClass = Loadouts(Requests, log, colors, Server, current_map)
     table = Table(cfg, log)

--- a/main.py
+++ b/main.py
@@ -253,10 +253,8 @@ try:
                     time.sleep(2)
                 log(f"first game state: {game_state}")
             else:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
                 previous_game_state = game_state
-                game_state = loop.run_until_complete(
+                game_state = asyncio.run(
                     Wss.recconect_to_websocket(game_state)
                 )
                 # We invalidate the cached responses when going from any state to menus
@@ -266,7 +264,6 @@ try:
                     if hasattr(pstats, "clear_runtime_cache"):
                         pstats.clear_runtime_cache()
                 log(f"new game state: {game_state}")
-                loop.close()
             firstTime = False
             # loop = asyncio.new_event_loop()
             # asyncio.set_event_loop(loop)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 certifi==2024.7.4
 charset-normalizer==3.2.0
-Colr==0.9.1
 idna==3.7
 inquirerpy==0.3.4
 markdown-it-py==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from src.constants import version
 build_exe_options = {
     "path": sys.path,
     "include_files":['configurator.bat', 'updatescript.bat'],
-    "packages": ["requests", "colr", "InquirerPy", "websockets", "pypresence", "nest_asyncio", "rich", "websocket_server"],
+    "packages": ["requests", "InquirerPy", "websockets", "pypresence", "nest_asyncio", "rich", "websocket_server"],
     "excludes": ["tkinter", "test", "unittest", "pygments", "xmlrpc"]
 }
 

--- a/src/Loadouts.py
+++ b/src/Loadouts.py
@@ -1,6 +1,6 @@
 import time
 import requests
-from colr import color
+from src.colors import color
 from src.constants import sockets, hide_names
 import json
 

--- a/src/account_manager/account_auth.py
+++ b/src/account_manager/account_auth.py
@@ -107,7 +107,7 @@ class AccountAuth:
                 r = self.session.put("https://auth.riotgames.com/api/v1/authorization", json=body, headers=self.headers)
             if r.json().get("error") == "auth_failure":
                 return None
-        pattern = re.compile('access_token=((?:[a-zA-Z]|\d|\.|-|_)*).*id_token=((?:[a-zA-Z]|\d|\.|-|_)*).*expires_in=(\d*)')
+        pattern = re.compile(r'access_token=((?:[a-zA-Z]|\d|\.|-|_)*).*id_token=((?:[a-zA-Z]|\d|\.|-|_)*).*expires_in=(\d*)')
         data = pattern.findall(r.json()['response']['parameters']['uri'])[0]
         access_token = data[0]
         id_token = data[1]

--- a/src/colors.py
+++ b/src/colors.py
@@ -1,13 +1,29 @@
-from colr import color
-from src.constants import tierDict
 import re
+from rich.console import Console
+from rich.text import Text
 
+_console = Console(force_terminal=True, color_system="truecolor", width=1000)
+
+def color(text, fore=None):
+    if fore is None:
+        return str(text)
+    
+    style = ""
+    if isinstance(fore, tuple) and len(fore) == 3:
+        style = f"rgb({fore[0]},{fore[1]},{fore[2]})"
+    else:
+        style = str(fore)
+    
+    t = Text(str(text), style=style)
+    with _console.capture() as capture:
+        _console.print(t, end="")
+    return capture.get()
 
 class Colors:
-    def __init__(self, log, hide_names, agent_dict, AGENTCOLORLIST):
+    def __init__(self, log, hide_names, agent_dict, AGENTCOLORLIST, tier_dict):
         self.hide_names = hide_names
         self.agent_dict = agent_dict
-        self.tier_dict = tierDict
+        self.tier_dict = tier_dict
         self.AGENTCOLORLIST = AGENTCOLORLIST
         self.log = log
 
@@ -103,17 +119,17 @@ class Colors:
                         f.append(
                             int(
                                 gradients[gradient][0][rgb]
-                                - offset * number / gradient[1]
+                                - offset * (number - gradient[0]) / (gradient[1] - gradient[0])
                             )
                         )
                     else:
                         f.append(
                             int(
-                                offset * number / gradient[1]
+                                offset * (number - gradient[0]) / (gradient[1] - gradient[0])
                                 + gradients[gradient][0][rgb]
                             )
                         )
-                return color(number, fore=f)
+                return color(number, fore=tuple(f))
 
     def get_wr_gradient(self, number):
         try:
@@ -149,17 +165,17 @@ class Colors:
                         f.append(
                             int(
                                 gradients[gradient][0][rgb]
-                                - offset * number / gradient[1]
+                                - offset * (number - gradient[0]) / (gradient[1] - gradient[0])
                             )
                         )
                     else:
                         f.append(
                             int(
-                                offset * number / gradient[1]
+                                offset * (number - gradient[0]) / (gradient[1] - gradient[0])
                                 + gradients[gradient][0][rgb]
                             )
                         )
-                return color(number, fore=f)
+                return color(number, fore=tuple(f))
 
     def get_rr_gradient(self, rr_value, afk_penalty):
         """Returns RR value in green if positive, red if negative, white if zero, and AFK penalty in a different color."""

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,5 +1,5 @@
 import requests
-from colr import color
+from src.colors import color
 
 version = "2.93"
 enablePrivateLogging = True

--- a/src/requestsV.py
+++ b/src/requestsV.py
@@ -3,7 +3,7 @@ import json
 import time
 from json.decoder import JSONDecodeError
 import requests
-from colr import color
+from src.colors import color
 import os
 import shutil
 import sys

--- a/src/websocket.py
+++ b/src/websocket.py
@@ -5,7 +5,7 @@ import ssl
 import base64
 import json
 import asyncio
-from colr import color
+from src.colors import color
 
 class Ws:
     def __init__(self, lockfile, Requests, cfg, colors, hide_names, server, rpc=None):


### PR DESCRIPTION
[Tested on python 3.14.3]
* Switched to rich, since Colr is no longer updated and maintained. (resolves the unknown typing.io import)
* Refactor the websocket reconnection logic to use asyncio.run(). (ensures compatibility with the stricter loop management)
* Resolve regex SyntaxErrors by treating regex as a raw string

Also as a side fix for colours which i noticed: 
* The previous gradient calculation was incorrect for ranges that did not start at zero. It was using number / gradient[1], which failed to correctly calculate values within the sub-range. The gradient will now be accurately calculated 