### PR TITLE
fix: prevent non-dict crash in presence decoding

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,7 +1,7 @@
 import requests
 from colr import color
 
-version = "2.93"
+version = "2.94"
 enablePrivateLogging = True
 hide_names = True
 hide_levels = True

--- a/src/presences.py
+++ b/src/presences.py
@@ -47,11 +47,10 @@ class Presences:
         return None
 
     def decode_presence(self, private):
-        # try:
         if "{" not in str(private) and private is not None and str(private) != "":
-            dict = json.loads(base64.b64decode(str(private)).decode("utf-8"))
-            if dict.get("isValid"):
-                return dict
+            decoded_party_presence = json.loads(base64.b64decode(str(private)).decode("utf-8"))
+            if isinstance(decoded_party_presence, dict) and decoded_party_presence.get('isValid'):
+                return decoded_party_presence
         return {
             "isValid": False,
             "partyId": 0,


### PR DESCRIPTION
## Summary
Prevents a crash in function `decode_presence` when the decoded base64 JSON payload is not a dictionary.

## Changes
- Rename variable from `dict` to `decoded_party_presence`
- Add `isinstance(..., dict)` before calling `.get('isValid')`